### PR TITLE
Specify full path to binaries in toolchain images.

### DIFF
--- a/gcc-cpp/src/manifest.yaml
+++ b/gcc-cpp/src/manifest.yaml
@@ -5,7 +5,7 @@ build-limits:
   time: 6000
 build:
   - argv:
-      - g++
+      - /usr/bin/g++
       - $(Run.SourceFilePath)
       - -o
       - $(Run.BinaryFilePath)

--- a/gcc/src/manifest.yaml
+++ b/gcc/src/manifest.yaml
@@ -5,7 +5,7 @@ build-limits:
   time: 6000
 build:
   - argv:
-      - gcc
+      - /usr/bin/gcc
       - $(Run.SourceFilePath)
       - -o
       - $(Run.BinaryFilePath)

--- a/python3/src/manifest.yaml
+++ b/python3/src/manifest.yaml
@@ -9,5 +9,5 @@ build:
     - $(Run.BinaryFilePath)
 run:
   argv:
-    - python3
+    - /usr/bin/python3
     - $(Run.BinaryFilePath)


### PR DESCRIPTION
Without this worker fails to find compiler image.

Signed-off-by: Pavel Kalugin <paul.kalug@gmail.com>
